### PR TITLE
Remove unused REQUEST_URI constant from request spec

### DIFF
--- a/test/unit/transloadit/test_request.rb
+++ b/test/unit/transloadit/test_request.rb
@@ -1,8 +1,6 @@
 require 'test_helper'
 
 describe Transloadit::Request do
-  REQUEST_URI = 'http://api2.jane.transloadit.com/assemblies/76fe5df1c93a0a530f3e583805cf98b4'
-
   before do
     # reset the API endpoint between tests
     Transloadit::Request.api Transloadit::Request::API_ENDPOINT


### PR DESCRIPTION
This constant doesn't appear to be necessary and is the source of a warning when running the specs together via rake.
