### PR TITLE
Style tweaks for more Rubyish, less Pythonic code

### DIFF
--- a/lib/transloadit.rb
+++ b/lib/transloadit.rb
@@ -35,12 +35,12 @@ class Transloadit
   #   signing requests (optional)
   #
   def initialize(options = {})
-    self.key      = options[:key]
-    self.secret   = options[:secret]
-    self.duration = options[:duration] || 5 * 60
-    self.max_size = options[:max_size]
+    @key      = options[:key]
+    @secret   = options[:secret]
+    @duration = options[:duration] || 5 * 60
+    @max_size = options[:max_size]
 
-    _ensure_key_provided
+    ensure_key_provided
   end
 
   #
@@ -79,16 +79,16 @@ class Transloadit
   # @return [String] a human-readable version of the Transloadit.
   #
   def inspect
-    self.to_hash.inspect
+    to_hash.inspect
   end
 
   #
   # @return [Hash] a Transloadit-compatible Hash of the instance's contents
   #
   def to_hash
-    result = { :key => self.key }
-    result.update(:max_size => self.max_size) unless self.max_size.nil?
-    result.update(:expires => _generate_expiry) unless self.secret.nil?
+    result = { :key => @key }
+    result.update(:max_size => @max_size) unless @max_size.nil?
+    result.update(:expires => generate_expiry) unless @secret.nil?
     result
   end
 
@@ -96,7 +96,7 @@ class Transloadit
   # @return [String] JSON-encoded String containing the object's hash contents
   #
   def to_json
-    MultiJson.dump(self.to_hash)
+    MultiJson.dump(to_hash)
   end
 
   private
@@ -104,8 +104,8 @@ class Transloadit
   #
   # Raises an ArgumentError if no {#key} has been assigned.
   #
-  def _ensure_key_provided
-    unless self.key
+  def ensure_key_provided
+    unless @key
       raise ArgumentError, 'an authentication key must be provided'
     end
   end
@@ -116,7 +116,7 @@ class Transloadit
   #
   # @return [String] an API-compatible timestamp
   #
-  def _generate_expiry
-    (Time.now + self.duration).utc.strftime('%Y/%m/%d %H:%M:%S+00:00')
+  def generate_expiry
+    (Time.now + @duration).utc.strftime('%Y/%m/%d %H:%M:%S+00:00')
   end
 end

--- a/lib/transloadit/response.rb
+++ b/lib/transloadit/response.rb
@@ -12,7 +12,7 @@ class Transloadit::Response < Delegator
   # @param [RestClient::Response] response the JSON response to wrap
   #
   def initialize(response)
-    self.__setobj__(response)
+    __setobj__(response)
   end
 
   #
@@ -22,7 +22,7 @@ class Transloadit::Response < Delegator
   # @return [String]           the value for the attribute
   #
   def [](attribute)
-    self.body[attribute.to_s]
+    body[attribute.to_s]
   end
 
   #
@@ -31,7 +31,7 @@ class Transloadit::Response < Delegator
   # @return [Hash] the parsed JSON body hash
   #
   def body
-    MultiJson.load self.__getobj__.body
+    MultiJson.load __getobj__.body
   end
 
   #
@@ -40,7 +40,7 @@ class Transloadit::Response < Delegator
   # @return [String] a human-readable version of the body
   #
   def inspect
-    self.body.inspect
+    body.inspect
   end
 
   #
@@ -84,7 +84,7 @@ class Transloadit::Response < Delegator
   # @return [Transloadit::Response] this response
   #
   def replace(other)
-    self.__setobj__ other.__getobj__
+    __setobj__ other.__getobj__
     self
   end
 end

--- a/lib/transloadit/response/assembly.rb
+++ b/lib/transloadit/response/assembly.rb
@@ -2,11 +2,11 @@ require 'transloadit'
 
 module Transloadit::Response::Assembly
   def reload!
-    self.replace Transloadit::Request.new(self['assembly_url']).get
+    replace Transloadit::Request.new(self['assembly_url']).get
   end
 
   def cancel!
-    self.replace Transloadit::Request.new(self['assembly_url']).delete
+    replace Transloadit::Request.new(self['assembly_url']).delete
   end
 
   def aborted?

--- a/lib/transloadit/step.rb
+++ b/lib/transloadit/step.rb
@@ -27,9 +27,9 @@ class Transloadit::Step
   #   {Transloadit#step} for possible values
   #
   def initialize(name, robot, options = {})
-    self.name    = name
-    self.robot   = robot
-    self.options = options
+    @name    = name
+    @robot   = robot
+    @options = options
   end
 
   #
@@ -49,9 +49,9 @@ class Transloadit::Step
   #   that will actually be sent to the REST API.
   #
   def use(input)
-    self.options.delete(:use) and return if input.nil?
+    @options.delete(:use) and return if input.nil?
 
-    self.options[:use] = case input
+    @options[:use] = case input
       when Symbol then input.inspect
       when Array  then input.map {|i| i.name }
       else             [ input.name ]
@@ -62,24 +62,20 @@ class Transloadit::Step
   # @return [String] a human-readable version of the Step
   #
   def inspect
-    self.to_hash[self.name].inspect
+    to_hash[@name].inspect
   end
 
   #
   # @return [Hash] a Transloadit-compatible Hash of the Step's contents
   #
   def to_hash
-    { self.name => options.merge(:robot => self.robot) }
+    { @name => @options.merge(:robot => @robot) }
   end
 
   #
   # @return [String] JSON-encoded String containing the Step's hash contents
   #
   def to_json
-    MultiJson.dump(self.to_hash)
+    MultiJson.dump(to_hash)
   end
-
-  protected
-
-  attr_writer :robot
 end


### PR DESCRIPTION
- Prefer at sigil notation for getting/setting ivars instead of attr methods
- Remove leading underscores from private method names
- Remove explicit calls to self as receiver
