### PR TITLE
Remove Ruby 1.8 support. Gem requires 1.9.2 at least.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 language: ruby
 rvm:
-  - ree
-  - 1.8.7
   - 1.9.2
   - 1.9.3
   - 2.0.0
   - 2.1.0
   - rbx-2
-  - jruby-18mode
   - jruby-19mode
 script: "COVERAGE=false bundle exec rake test"

--- a/README.md
+++ b/README.md
@@ -214,11 +214,11 @@ for the latest [git master](http://rubydoc.info/github/transloadit/ruby-sdk/mast
 
 ## Compatibility
 
-At a minimum, this gem should work on MRI 2.1.0, 2.0.0, 1.9.3, 1.9.2, 1,8.7, Rubinius,
-and JRuby in both 1.8 mode and 1.9 mode. It may also work on 1.8.6, but support for those
+At a minimum, this gem should work on MRI 2.1.0, 2.0.0, 1.9.3, 1.9.2, Rubinius,
+and JRuby in 1.9 mode. It may also work on older ruby versions, but support for those
 Rubies is not guaranteed. If it doesn't work on one of the officially supported Rubies, please file a
 [bug report](https://github.com/transloadit/ruby-sdk/issues). Compatibility patches for other Rubies
-are welcomed.
+are welcome.
 
 Testing against these versions is performed automatically by
 [Travis CI](https://travis-ci.org/transloadit/ruby-sdk).

--- a/transloadit.gemspec
+++ b/transloadit.gemspec
@@ -15,22 +15,18 @@ Gem::Specification.new do |gem|
   gem.description = 'The transloadit gem allows you to automate uploading files through the Transloadit REST API'
 
   gem.required_rubygems_version = '>= 1.3.6'
+  gem.required_ruby_version     = '>= 1.9.2'
   gem.rubyforge_project         = 'transloadit'
 
   gem.files         = `git ls-files`.split("\n")
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.require_paths = %w{ lib }
 
-  if RUBY_VERSION < '1.9'
-    gem.add_dependency 'rest-client', '< 1.7.0'
-  else
-    gem.add_dependency 'rest-client'
-  end
+  gem.add_dependency 'rest-client'
   gem.add_dependency 'multi_json'
-  gem.add_dependency 'mime-types', '< 2.0.0' if RUBY_VERSION < '1.9'
+  gem.add_dependency 'mime-types'
 
   gem.add_development_dependency 'rake'
-  gem.add_development_dependency 'minitest' # needed for < 1.9.2
   gem.add_development_dependency 'simplecov'
 
   gem.add_development_dependency 'vcr'


### PR DESCRIPTION
With rest-client being another dependency that stopped supporting 1.8 and given the EOL of 1.8 in general (even 1.9.2 is EOLed already), I thought it's wise to remove the official 1.8 support for this gem.

I initially attempted to fix the install on 1.8 with d607d377fc68c76c652ec980eae9e64666013aac, but the gemspec is evaluated at creation time and not runtime, thus needing us to do hacks like described [in here](http://www.programmersparadox.com/2012/05/21/gemspec-loading-dependent-gems-based-on-the-users-system).

By now everyone should have their production ruby at least on 1.9.2, so I think it's safe to remove the support. Open for discussion though.

If this gets merged, I'd go forward and release version 2.0.0 (even though we don't break backwards incompatible code with this release, but just to notion that we have a different version requirement now). Same goes for transloadit/rails-sdk then :)

/cc @stouset