### PR TITLE
Do not delete fields hash

### DIFF
--- a/lib/transloadit/assembly.rb
+++ b/lib/transloadit/assembly.rb
@@ -82,7 +82,7 @@ class Transloadit::Assembly
     self.options.merge(
       :auth  => self.transloadit.to_hash,
       :steps => self.steps
-    ).delete_if {|k,v| v.nil? || k == :fields}
+    ).delete_if {|k,v| v.nil?}
   end
 
   #

--- a/test/unit/transloadit/test_assembly.rb
+++ b/test/unit/transloadit/test_assembly.rb
@@ -104,7 +104,7 @@ describe Transloadit::Assembly do
           assert_requested(:post, 'jane.transloadit.com/assemblies') do |req|
             values = values_from_post_body(req.body)
             values['tag'].must_equal 'ninja-cat'
-            MultiJson.load(values['params'])['fields'].must_equal 'ninja-cat'
+            MultiJson.load(values['params'])['fields']['tag'].must_equal 'ninja-cat'
           end
         end
       end

--- a/test/unit/transloadit/test_assembly.rb
+++ b/test/unit/transloadit/test_assembly.rb
@@ -104,7 +104,7 @@ describe Transloadit::Assembly do
           assert_requested(:post, 'jane.transloadit.com/assemblies') do |req|
             values = values_from_post_body(req.body)
             values['tag'].must_equal 'ninja-cat'
-            MultiJson.load(values['params'])['fields'].must_be_nil
+            MultiJson.load(values['params'])['fields'].must_equal 'ninja-cat'
           end
         end
       end


### PR DESCRIPTION
After merging the fields hash into the payload (https://github.com/transloadit/ruby-sdk/blob/e4e2e376ff2e6a2a5d51c08ece0d059f4bd0b4f7/lib/transloadit/assembly.rb#L55), it is deleted entirely from the hash (https://github.com/transloadit/ruby-sdk/blob/e4e2e376ff2e6a2a5d51c08ece0d059f4bd0b4f7/lib/transloadit/assembly.rb#L85). This prevents users from supplying customs field values inside the params, such as:

```json
{
    "template_id": "....",
    "fields": {
        "watermark_url": "https://..."
    },
    "auth": {
        "key": "****",
        "expires": "2015/12/26 21:54:51+00:00"
    }
}
```

In my mind, this deletion does not serve any purpose and should not be done. I would be pleased, if you could provide some more details. :)