### PR TITLE
Add Response#reload_until_finished!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
   * update to update a particular template.
   * delete to delete a particular template.
 * Add rate limit feature to implicitly retry assembly creation when the rate limit is reached.
+* Add `assembly.reload_until_finished!` which calls `reload!` once per second until assembly is finished
 
 ### 1.2.0 / 2015-12-28 ###
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ assembly = transloadit.assembly(
 
 response = assembly.create! open('lolcat.jpg')
 
-# blocks and polls REST API once per second until all processing is finished
+# reloads the response once per second until all processing is finished
 response.reload_until_finished!
 
 if response.error?

--- a/README.md
+++ b/README.md
@@ -69,10 +69,8 @@ assembly = transloadit.assembly(
 
 response = assembly.create! open('lolcat.jpg')
 
-# loop until processing is finished
-until response.finished?
-  sleep 1; response.reload! # you'll want to implement a timeout in your production app
-end
+# blocks and polls REST API once per second until all processing is finished
+response.reload_until_finished!
 
 if response.error?
  # handle error
@@ -119,6 +117,10 @@ assembly to reload its results from the API.
 ```ruby
 # reloads the response's contents from the REST API
 response.reload!
+
+# reloads once per second until all processing is finished, up to number of 
+# times specified in :tries option, othewise will raise ReloadLimitReached
+response.reload_until_finished! tries: 300 # default is 600
 ```
 
 In general, you use hash accessor syntax to query any direct attribute from

--- a/lib/transloadit/exception.rb
+++ b/lib/transloadit/exception.rb
@@ -15,4 +15,13 @@ module Transloadit::Exception
       "Transloadit Rate Limit Reached.#{retry_msg}"
     end
   end
+
+  #
+  # Exception raised when Response#reload_until_finished! reaches limit specified in :tries option
+  #
+  class ReloadLimitReached < StandardError
+    def message
+      "reload_until_finished! reached limit specified in :tries option. This is not a rate limit and you may continue to poll for updates."
+    end
+  end
 end

--- a/lib/transloadit/response/assembly.rb
+++ b/lib/transloadit/response/assembly.rb
@@ -55,8 +55,8 @@ module Transloadit::Response::Assembly
     tries = options[:tries] || DEFAULT_RELOAD_TRIES
 
     tries.times do
-      return self if finished?
       sleep 1; reload!
+      return self if finished?
     end
 
     raise Transloadit::Exception::ReloadLimitReached

--- a/lib/transloadit/response/assembly.rb
+++ b/lib/transloadit/response/assembly.rb
@@ -51,7 +51,7 @@ module Transloadit::Response::Assembly
 
   DEFAULT_RELOAD_TRIES = 600
 
-  def reload_until_finished! options = {}
+  def reload_until_finished!(options = {})
     tries = options[:tries] || DEFAULT_RELOAD_TRIES
 
     tries.times do

--- a/lib/transloadit/response/assembly.rb
+++ b/lib/transloadit/response/assembly.rb
@@ -48,4 +48,17 @@ module Transloadit::Response::Assembly
   def wait_time
     self['info']['retryIn'] || 0
   end
+
+  DEFAULT_RELOAD_TRIES = 600
+
+  def reload_until_finished! options = {}
+    tries = options[:tries] || DEFAULT_RELOAD_TRIES
+
+    tries.times do
+      return self if finished?
+      sleep 1; reload!
+    end
+
+    raise Transloadit::Exception::ReloadLimitReached
+  end
 end


### PR DESCRIPTION
This adds a Response#reload_until_finished! method, which blocks and polls the REST API once per second until all processing has completed, up to the number of specified :tries (default is 600.)

Proposed in issue #37 