### PR TITLE
Fix note rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ else
 end
 ```
 
-<div class="tip" markdown="1">
-  The <dfn>Assembly</dfn> method `submit!` has been deprecated and replaced with `create!`.
-  The `submit!` method remains as an alias of `create!` for backward Compatibility.
+<div class="alert alert-note">
+  <strong>Note:</strong> The <dfn>Assembly</dfn> method <code>submit!</code> has been deprecated and replaced with <code>create!</code>.
+  The <code>submit!</code> method remains as an alias of <code>create!</code> for backward Compatibility.
 </div>
 
 When the `create!` method returns, the file has been uploaded but may not yet


### PR DESCRIPTION
_Before:_

<img width="874" alt="image" src="https://user-images.githubusercontent.com/375537/165295208-881a2a2f-6f45-40d5-8917-3b6ad1d1e270.png">

_After:_

<img width="853" alt="image" src="https://user-images.githubusercontent.com/375537/165295299-60a837e7-e3d0-47f0-bac9-e7addbc0a3e3.png">

* * *

This also has effect on the Transloadit website where the note will be looking as expected.

_Before:_

<img width="848" alt="image" src="https://user-images.githubusercontent.com/375537/165295509-45c2961e-7bf4-4589-88e7-3274ce0b750d.png">

_After:_

<img width="859" alt="image" src="https://user-images.githubusercontent.com/375537/165297256-84abf4c3-5c0f-4177-8025-360aa9bf9792.png">
