### PR TITLE
Update for Ruby 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,9 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 2.2
-          - 2.3
-          - 2.4
-          - 2.5
-          - 2.6
-          - 2.7
+          - 3.0
+          - 3.1
+          - 3.2
           - jruby
           # - jruby-head
           - truffleruby
@@ -22,6 +19,5 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - if: ${{ matrix.ruby == '2.5' }}
-        run: bundle exec standardrb
+      - run: bundle exec standardrb
       - run: COVERAGE=false bundle exec rake test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 3.0.0 / ????-??-?? ###
 
+* BREAKING: Drop support for EOL'd Ruby 2.x
 * Prevent duplicate assembly steps [#49](https://github.com/transloadit/ruby-sdk/issues/27) (@ifedapoolarewaju)
 * Send "Transloadit-Client" header for every request (@ifedapoolarewaju)
 

--- a/README.md
+++ b/README.md
@@ -421,7 +421,6 @@ for the latest [git master](http://rubydoc.info/github/transloadit/ruby-sdk/mast
 Please see [ci.yml](https://github.com/transloadit/ruby-sdk/tree/master/.github/workflows/ci.yml) for a list of supported ruby versions. It may also work on older Rubies, but support for those is not guaranteed. If it doesn't work on one of the officially supported Rubies, please file a
 [bug report](https://github.com/transloadit/ruby-sdk/issues). Compatibility patches for other Rubies are welcome.
 
-### Ruby 1.9.x & 2.0
+### Ruby 2.x
 
-If you still need support for older versions of Ruby, 1.2.0 is the last version that
-supports those.
+If you still need support for Ruby 2.x, 2.0.1 is the last version that supports it.

--- a/lib/transloadit/assembly.rb
+++ b/lib/transloadit/assembly.rb
@@ -71,7 +71,7 @@ class Transloadit::Assembly < Transloadit::ApiModel
   # keeping this method for backward compatibility
   #
   def submit!(*ios)
-    warn "#{caller(1..1).first}: warning: Transloadit::Assembly#submit!"\
+    warn "#{caller(1..1).first}: warning: Transloadit::Assembly#submit!" \
       " is deprecated. use Transloadit::Assembly#create! instead"
     create!(*ios)
   end
@@ -140,14 +140,14 @@ class Transloadit::Assembly < Transloadit::ApiModel
   #
   def _wrap_steps_in_hash(steps)
     case steps
-      when nil then steps
-      when Hash then steps
-      when Transloadit::Step then steps.to_hash
-      else
-        if steps.uniq(&:name) != steps
-          raise ArgumentError, "There are different Assembly steps using the same name"
-        end
-        steps.inject({}) { |h, s| h.update s }
+    when nil then steps
+    when Hash then steps
+    when Transloadit::Step then steps.to_hash
+    else
+      if steps.uniq(&:name) != steps
+        raise ArgumentError, "There are different Assembly steps using the same name"
+      end
+      steps.inject({}) { |h, s| h.update s }
     end
   end
 

--- a/lib/transloadit/request.rb
+++ b/lib/transloadit/request.rb
@@ -158,9 +158,8 @@ class Transloadit::Request
     return "" if params.nil?
     return "" if params.respond_to?(:empty?) && params.empty?
 
-    escape = Regexp.new("[^#{URI::PATTERN::UNRESERVED}]")
     params_in_json = MultiJson.dump(params)
-    uri_params = URI.escape(params_in_json, escape)
+    uri_params = URI.encode_www_form_component(params_in_json)
 
     params = {
       params: uri_params,

--- a/lib/transloadit/request.rb
+++ b/lib/transloadit/request.rb
@@ -122,8 +122,8 @@ class Transloadit::Request
   #
   def api(options = {})
     @api ||= case url.host
-        when String then RestClient::Resource.new(url.host, options)
-        else RestClient::Resource.new(API_ENDPOINT.host, options)
+    when String then RestClient::Resource.new(url.host, options)
+    else RestClient::Resource.new(API_ENDPOINT.host, options)
     end
   end
 

--- a/lib/transloadit/step.rb
+++ b/lib/transloadit/step.rb
@@ -52,9 +52,9 @@ class Transloadit::Step
     options.delete(:use) && return if input.nil?
 
     options[:use] = case input
-      when Symbol then input.inspect
-      when Array then input.map { |i| i.name }
-      else [input.name]
+    when Symbol then input.inspect
+    when Array then input.map { |i| i.name }
+    else [input.name]
     end
   end
 

--- a/test/unit/transloadit/test_assembly.rb
+++ b/test/unit/transloadit/test_assembly.rb
@@ -89,7 +89,7 @@ describe Transloadit::Assembly do
 
       it "must allow steps through the create! method" do
         Transloadit::Assembly.new(@transloadit).create!(
-          **{steps: @transloadit.step("thumbs", "/video/thumbs")}
+          steps: @transloadit.step("thumbs", "/video/thumbs")
         )
 
         assert_requested(:post, "api2.transloadit.com/assemblies") do |req|
@@ -99,7 +99,7 @@ describe Transloadit::Assembly do
       end
 
       it "must allow steps passed through the create! method override steps previously set" do
-        @assembly.create!(**{steps: @transloadit.step("resize", "/image/resize")})
+        @assembly.create!(steps: @transloadit.step("resize", "/image/resize"))
 
         assert_requested(:post, "api2.transloadit.com/assemblies") do |req|
           values = values_from_post_body(req.body)

--- a/test/unit/transloadit/test_assembly.rb
+++ b/test/unit/transloadit/test_assembly.rb
@@ -89,7 +89,7 @@ describe Transloadit::Assembly do
 
       it "must allow steps through the create! method" do
         Transloadit::Assembly.new(@transloadit).create!(
-          {steps: @transloadit.step("thumbs", "/video/thumbs")}
+          **{steps: @transloadit.step("thumbs", "/video/thumbs")}
         )
 
         assert_requested(:post, "api2.transloadit.com/assemblies") do |req|
@@ -99,7 +99,7 @@ describe Transloadit::Assembly do
       end
 
       it "must allow steps passed through the create! method override steps previously set" do
-        @assembly.create!({steps: @transloadit.step("resize", "/image/resize")})
+        @assembly.create!(**{steps: @transloadit.step("resize", "/image/resize")})
 
         assert_requested(:post, "api2.transloadit.com/assemblies") do |req|
           values = values_from_post_body(req.body)
@@ -112,7 +112,7 @@ describe Transloadit::Assembly do
       it "must call the create! method with the same parameters" do
         VCR.use_cassette "submit_assembly" do
           file = open("lib/transloadit/version.rb")
-          mocker = MiniTest::Mock.new
+          mocker = Minitest::Mock.new
           mocker.expect :call, nil, [file]
           @assembly.stub :create!, mocker do
             @assembly.submit!(file)
@@ -172,7 +172,7 @@ describe Transloadit::Assembly do
       thumbs_duplicate = @transloadit.step("thumbs", "/video/encode")
       options = {steps: [thumbs, thumbs_duplicate]}
       assert_raises ArgumentError do
-        @assembly.create! open("lib/transloadit/version.rb"), options
+        @assembly.create! open("lib/transloadit/version.rb"), **options
       end
     end
   end

--- a/transloadit.gemspec
+++ b/transloadit.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.1.0"
 
   gem.files = `git ls-files`.split("\n")
-  gem.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.require_paths = %w[lib]
 
   gem.add_dependency "rest-client"

--- a/transloadit.gemspec
+++ b/transloadit.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.description = "The transloadit gem allows you to automate uploading files through the Transloadit REST API"
 
   gem.required_rubygems_version = ">= 2.2.0"
-  gem.required_ruby_version = ">= 2.1.0"
+  gem.required_ruby_version = ">= 3.0.0"
 
   gem.files = `git ls-files`.split("\n")
   gem.require_paths = %w[lib]


### PR DESCRIPTION
This PR removes support for the EOL'd Ruby 2.x versions and updates it to be compatible with Ruby 3.x.