### PR TITLE
feat: default to SHA-384 for signature authentication

### DIFF
--- a/lib/transloadit/request.rb
+++ b/lib/transloadit/request.rb
@@ -203,6 +203,6 @@ class Transloadit::Request
   # @return [String] the HMAC signature for the params
   #
   def signature(params)
-    self.class._hmac(secret, params) if secret.to_s.length > 0
+    "sha384:" + self.class._hmac(secret, params) if secret.to_s.length > 0
   end
 end

--- a/lib/transloadit/request.rb
+++ b/lib/transloadit/request.rb
@@ -16,7 +16,7 @@ class Transloadit::Request
   API_HEADERS = {"Transloadit-Client" => "ruby-sdk:#{Transloadit::VERSION}"}
 
   # The HMAC algorithm used for calculation request signatures.
-  HMAC_ALGORITHM = OpenSSL::Digest.new("sha1")
+  HMAC_ALGORITHM = OpenSSL::Digest.new("sha384")
 
   # @return [String] the API endpoint for the request
   attr_reader :url

--- a/test/fixtures/cassettes/fetch_root.yml
+++ b/test/fixtures/cassettes/fetch_root.yml
@@ -72,7 +72,7 @@ http_interactions:
   recorded_at: Fri, 08 Mar 2013 15:13:10 GMT
 - request:
     method: get
-    uri: https://api2.transloadit.com/?params=%7B%22params%22:%7B%22foo%22:%22bar%22%7D%7D&signature=78f291e3038e3eeb82d9f79e11a68fe7b858ee97
+    uri: https://api2.transloadit.com/?params=%7B%22params%22:%7B%22foo%22:%22bar%22%7D%7D&signature=sha384:edccc99aef8cb46e087e17093fbcd6a2316e2fbe31dc0842c4af87a52808d0736d94a3bd5774deca2c215b53804ca572
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
I haven't tested the change. Hopefully, if this a breaking change, the tests will report it.

Fixes: https://github.com/transloadit/rails-sdk/issues/70