### PR TITLE
Fix typos

### DIFF
--- a/lib/transloadit.rb
+++ b/lib/transloadit.rb
@@ -83,7 +83,7 @@ class Transloadit
   # Creates a Transloadit::Template instance ready to interact with its corresponding REST API.
   #
   # See the Transloadit {documentation}[https://transloadit.com/docs/api-docs/#template-api]
-  # for futher information on Templates and available endpoints.
+  # for further information on Templates and available endpoints.
   #
   def template(options = {})
     Transloadit::Template.new(self, options)

--- a/lib/transloadit/assembly.rb
+++ b/lib/transloadit/assembly.rb
@@ -4,7 +4,7 @@ require "transloadit"
 # Represents an Assembly API ready to make calls to the REST API endpoints.
 #
 # See the Transloadit {documentation}[https://transloadit.com/docs/api-docs/#assembly-api]
-# for futher information on Assemblies and available endpoints.
+# for further information on Assemblies and available endpoints.
 #
 class Transloadit::Assembly < Transloadit::ApiModel
   DEFAULT_TRIES = 3
@@ -23,7 +23,7 @@ class Transloadit::Assembly < Transloadit::ApiModel
   # at which point Transloadit will process and store the files according to the
   # rules in the Assembly.
   # See the Transloadit {documentation}[https://transloadit.com/docs/building-assembly-instructions]
-  # for futher information on Assemblies and their parameters.
+  # for further information on Assemblies and their parameters.
   #
   # Accepts as many IO objects as you wish to process in the assembly.
   # The last argument is an optional Hash

--- a/lib/transloadit/step.rb
+++ b/lib/transloadit/step.rb
@@ -6,7 +6,7 @@ require "transloadit"
 # +options+ specific to the chosen robot.
 #
 # See the Transloadit {documentation}[https://transloadit.com/docs/building-assembly-instructions]
-# for futher information on robot types and their parameters.
+# for further information on robot types and their parameters.
 #
 class Transloadit::Step
   # @return [String] the name to give the step

--- a/lib/transloadit/template.rb
+++ b/lib/transloadit/template.rb
@@ -4,7 +4,7 @@ require "transloadit"
 # Represents a Template API ready to interact with its corresponding REST API.
 #
 # See the Transloadit {documentation}[https://transloadit.com/docs/api-docs/#template-api]
-# for futher information on Templates and their parameters.
+# for further information on Templates and their parameters.
 #
 class Transloadit::Template < Transloadit::ApiModel
   #

--- a/test/unit/transloadit/test_assembly.rb
+++ b/test/unit/transloadit/test_assembly.rb
@@ -286,7 +286,7 @@ describe Transloadit::Assembly do
     end
 
     describe "when replaying assembly notification" do
-      it "must replay notification of sepcified assembly" do
+      it "must replay notification of specified assembly" do
         VCR.use_cassette "replay_assembly_notification" do
           response = @assembly.replay_notification "2ea5d21063ad11e6bc93e53395ce4e7d"
 


### PR DESCRIPTION
Found via `codespell -H`