### PR TITLE
Fix Array<Hash> support for steps

### DIFF
--- a/lib/transloadit/assembly.rb
+++ b/lib/transloadit/assembly.rb
@@ -144,7 +144,7 @@ class Transloadit::Assembly < Transloadit::ApiModel
     when Hash then steps
     when Transloadit::Step then steps.to_hash
     else
-      if steps.uniq(&:name) != steps
+      if steps.uniq != steps
         raise ArgumentError, "There are different Assembly steps using the same name"
       end
       steps.inject({}) { |h, s| h.update s }

--- a/lib/transloadit/assembly.rb
+++ b/lib/transloadit/assembly.rb
@@ -143,11 +143,22 @@ class Transloadit::Assembly < Transloadit::ApiModel
     when nil then steps
     when Hash then steps
     when Transloadit::Step then steps.to_hash
-    else
-      if steps.uniq(&:name) != steps
+    when Array
+      names = steps.inject([]) do |array, step|
+        case step
+        when Transloadit::Step then array << step.name
+        when Hash then array + step.keys.map(&:to_s)
+        else
+          raise ArgumentError, "Unsupported array element"
+        end
+      end
+
+      if names.uniq != names
         raise ArgumentError, "There are different Assembly steps using the same name"
       end
       steps.inject({}) { |h, s| h.update s }
+    else
+      raise ArgumentError, "Unsupported steps class"
     end
   end
 

--- a/lib/transloadit/step.rb
+++ b/lib/transloadit/step.rb
@@ -79,6 +79,10 @@ class Transloadit::Step
     MultiJson.dump(to_hash)
   end
 
+  def eql?(other)
+    name == other.name
+  end
+
   protected
 
   attr_writer :robot

--- a/test/unit/transloadit/test_assembly.rb
+++ b/test/unit/transloadit/test_assembly.rb
@@ -211,6 +211,30 @@ describe Transloadit::Assembly do
     end
   end
 
+  describe "with multiple hash steps" do
+    before do
+      @encode = { "encode": { "robot": "/video/encode" } }
+      @thumbs = { "thumbs": { "robot": "/video/thumbs" } }
+
+      @assembly = Transloadit::Assembly.new @transloadit,
+        steps: [@encode, @thumbs]
+    end
+
+    it "must wrap its steps into one hash" do
+      _(@assembly.to_hash[:steps].keys).must_include @encode.keys
+      _(@assembly.to_hash[:steps].keys).must_include @thumbs.keys
+    end
+
+    it "must not allow duplicate steps" do
+      thumbs = { "thumbs": { "robot": "/video/thumbs" } }
+      thumbs_duplicate = { "thumbs": { "robot": "/video/encode" } }
+      options = {steps: [thumbs, thumbs_duplicate]}
+      assert_raises ArgumentError do
+        @assembly.create! open("lib/transloadit/version.rb"), **options
+      end
+    end
+  end
+
   describe "using assembly API methods" do
     include WebMock::API
 

--- a/test/unit/transloadit/test_assembly.rb
+++ b/test/unit/transloadit/test_assembly.rb
@@ -213,6 +213,79 @@ describe Transloadit::Assembly do
     end
   end
 
+  describe "with multiple hash steps" do
+    it "must wrap its steps into one hash" do
+      hash_1 = {encode: {robot: "/video/encode"}, resize: {robot: "/image/resize"}}
+      hash_2 = {thumbs: {robot: "/video/thumbs"}}
+
+      assembly = Transloadit::Assembly.new @transloadit,
+        steps: [hash_1, hash_2]
+      (hash_1.keys + hash_2.keys).each do |key|
+        _(assembly.to_hash[:steps].keys).must_include key
+      end
+    end
+
+    it "must not allow duplicate steps" do
+      thumbs = {thumbs: {robot: "/video/thumbs"}}
+      thumbs_duplicate = {thumbs: {robot: "/video/encode"}}
+      assembly = Transloadit::Assembly.new @transloadit,
+        steps: [thumbs, thumbs_duplicate]
+      assert_raises ArgumentError do
+        assembly.create! open("lib/transloadit/version.rb")
+      end
+    end
+  end
+
+  describe "with mixture of hashes and steps" do
+    it "must wrap its steps into one hash" do
+      hash = {encode: {robot: "/video/encode"}, resize: {robot: "/image/resize"}}
+      step = @transloadit.step "thumbs", "/video/thumbs"
+
+      assembly = Transloadit::Assembly.new @transloadit,
+        steps: [hash, step]
+
+      hash.keys.each do |key|
+        _(assembly.to_hash[:steps].keys).must_include key
+      end
+
+      _(assembly.to_hash[:steps].keys).must_include step.name
+    end
+
+    it "must not allow duplicate steps" do
+      hash = {thumbs: {robot: "/video/thumbs"}}
+      step = @transloadit.step "thumbs", "/video/thumbs"
+
+      assembly = Transloadit::Assembly.new @transloadit,
+        steps: [hash, step]
+
+      assert_raises ArgumentError do
+        assembly.create! open("lib/transloadit/version.rb")
+      end
+    end
+  end
+
+  describe "with unsupported step class" do
+    it "raises error" do
+      assembly = Transloadit::Assembly.new @transloadit,
+        steps: Class.new
+
+      assert_raises ArgumentError do
+        assembly.create! open("lib/transloadit/version.rb")
+      end
+    end
+  end
+
+  describe "with unsupported array element" do
+    it "raises error" do
+      assembly = Transloadit::Assembly.new @transloadit,
+        steps: [Class.new]
+
+      assert_raises ArgumentError do
+        assembly.create! open("lib/transloadit/version.rb")
+      end
+    end
+  end
+
   describe "using assembly API methods" do
     include WebMock::API
 


### PR DESCRIPTION
Hello,

https://github.com/transloadit/ruby-sdk/pull/50 this pull request breaks the support for `Array<Hash>` support for steps which we came across while trying to upgrade from v2 -> v3.