### PR TITLE
Pin third-party GitHub Actions to SHAs and update Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: bundle exec rake test
       - name: Upload coverage to Codecov
         if: matrix.ruby == '3.3'
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/coverage.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           node-version: 20
       - run: npm install -g tsx
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
@@ -37,7 +37,7 @@ jobs:
         run: bundle exec rake test
       - name: Upload coverage to Codecov
         if: matrix.ruby == '3.3'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/coverage.json
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f
         with:
           ruby-version: 3.3
           bundler-cache: true


### PR DESCRIPTION
Why:

Third-party GitHub Action tags can move after review. Pinning these references to full commit SHAs makes the workflow supply-chain input immutable and prepares the repo for stricter GitHub Actions allowlist policy.

What:

- Replaced floating third-party action refs with pinned commits.
- Updated Codecov to the current v6 action before pinning it.
- Left first-party, GitHub-owned, and already SHA-pinned actions unchanged.

Changed workflows:

- `.github/workflows/ci.yml`

Resolved refs:

- `codecov/codecov-action@v5` -> `codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe`
- `ruby/setup-ruby@v1` -> `ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f`

Verification:

- `git diff --check`
- Ruby YAML parse for changed workflow files
- Confirmed replaced floating refs no longer appear in changed workflows

Follow-up update:

- `codecov/codecov-action@v5` now resolves through the v6 commit `codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f` after v5 failed in Codecov CLI signature validation.
